### PR TITLE
1.0.6

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,5 +10,5 @@ charset = utf-8
 trim_trailing_whitespace = false
 insert_final_newline = false
 indent_style = tab
-indent_size = 5
+indent_size = 4
 max_line_length = 80

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "include_tt"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2024"
 authors = ["Denis Kotlyarov (Денис Котляров) <denis2005991@gmail.com>"]
 repository = "https://github.com/clucompany/include_tt.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ proc-macro = true
 
 [dependencies]
 quote = "1.0.40"
-proc-macro2 = "1.0.94"
+proc-macro2 = "1.0.95"
 
 [dependencies.syn]
-version = "2.0.100"
+version = "2.0.104"
 default-features = false
 features = ["parsing"]

--- a/examples/mrules.rs
+++ b/examples/mrules.rs
@@ -45,5 +45,5 @@ fn main() {
 		}
 	}
 	assert_eq!(n, a + b);
-	println!("n: {:?}", n); // 30
+	println!("n: {n:?}"); // 30
 }

--- a/src/exprs/literal.rs
+++ b/src/exprs/literal.rs
@@ -14,14 +14,14 @@ pub struct ExprLit {
 }
 
 impl PartialEq<ExprLit> for ExprLit {
-	#[inline(always)]
+	#[inline]
 	fn eq(&self, other: &ExprLit) -> bool {
 		PartialEq::eq(self.as_str(), other.as_str())
 	}
 }
 
 impl PartialEq<str> for ExprLit {
-	#[inline(always)]
+	#[inline]
 	fn eq(&self, other: &str) -> bool {
 		PartialEq::eq(self.as_str(), other)
 	}
@@ -56,21 +56,21 @@ impl ExprLitTryNewErr {
 impl Deref for ExprLit {
 	type Target = str;
 
-	#[inline(always)]
+	#[inline]
 	fn deref(&self) -> &Self::Target {
 		self.as_str()
 	}
 }
 
 impl Debug for ExprLit {
-	#[inline(always)]
+	#[inline]
 	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
 		Debug::fmt(self as &str, f)
 	}
 }
 
 impl Display for ExprLit {
-	#[inline(always)]
+	#[inline]
 	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
 		Display::fmt(self as &str, f)
 	}
@@ -102,7 +102,7 @@ impl ExprLit {
 	}
 
 	/// Creating `ExprLit` without clipping.
-	#[inline(always)]
+	#[inline]
 	pub const unsafe fn unchecked(a: &str) -> &Self {
 		Self::__new(a)
 	}
@@ -172,14 +172,14 @@ impl ExprLit {
 		})
 	}
 
-	#[inline(always)]
+	#[inline]
 	/// Returns `true` if self has a length of zero bytes.
 	pub const fn is_empty(&self) -> bool {
 		self.data.is_empty()
 	}
 
 	/// Getting a string of actual data.
-	#[inline(always)]
+	#[inline]
 	pub const fn as_str(&self) -> &str {
 		&self.data
 	}

--- a/src/exprs/literal.rs
+++ b/src/exprs/literal.rs
@@ -1,4 +1,4 @@
-use crate::sg_err;
+use crate::throw_sg_err;
 use alloc::{borrow::ToOwned, string::String};
 use core::{
 	borrow::Borrow,
@@ -43,10 +43,10 @@ impl ExprLitTryNewErr {
 	#[inline]
 	pub fn into_tt_err(self, span: Span) -> TokenStream2 {
 		match self {
-			Self::ExpLen { current, exp } => sg_err! {
+			Self::ExpLen { current, exp } => throw_sg_err! {
 				[span]: "More char expected, current: ", #current, "exp: {}", #exp, "."
 			},
-			Self::ExpQuotes => sg_err! {
+			Self::ExpQuotes => throw_sg_err! {
 				[span]: "Double quotes were expected."
 			},
 		}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ use alloc::string::ToString;
 use core::slice::IterMut;
 use proc_macro::TokenStream;
 use proc_macro2::{Group, TokenStream as TokenStream2, TokenTree as TokenTree2};
-use trees::sg_err;
+use crate::trees::throw_sg_err;
 
 /// Components, templates, code for the search
 /// and final construction of trees.
@@ -128,7 +128,7 @@ pub(crate) mod trees {
 	#[macro_use]
 	pub mod sq_err;
 	#[allow(clippy::single_component_path_imports)]
-	pub(crate) use sg_err;
+	pub(crate) use throw_sg_err;
 	pub mod loader;
 }
 
@@ -203,12 +203,12 @@ fn search_include_and_replacegroup(iter: &mut IterMut<'_, TokenTree2>) -> Search
 											}
 										}
 
-										sg_err! {
+										throw_sg_err! {
 											return [ident.span()]: "`;` was expected."
 										}
 									}
 
-									_ => sg_err! {
+									_ => throw_sg_err! {
 										return [ident.span()]: "Unknown macro, expected `include`, `include_tt`, `include_and_fix_unknown_start_token`, `include_tt_and_fix_unknown_start_token`, `include_str`, `include_arr`, `include_and_break`, `include_tt_and_break`, `include_and_fix_unknown_start_token_and_break`, `include_tt_and_fix_unknown_start_token_and_break`, `include_str_and_break`, `include_arr_and_break`."
 									},
 								}

--- a/src/macros/include.rs
+++ b/src/macros/include.rs
@@ -11,7 +11,12 @@ use alloc::string::String;
 use proc_macro2::{
 	Delimiter, Group, Literal, Span, TokenStream as TokenStream2, TokenTree as TokenTree2,
 };
-use std::{fs::File, io::Read};
+use std::{
+	borrow::Cow,
+	fs::File,
+	io::Read,
+	path::Path,
+};
 
 /// A trait that specifies the final behavior for the `include` macro.
 pub trait BehMacroInclude {
@@ -92,8 +97,9 @@ impl BehMacroInclude for IncludeTT {
 	) -> TreeResult<Self::Result> {
 		arg0.get_str_with_fns(
 			|sspath| {
+				let path = Path::new(sspath);
 				load_file_and_automake_tree_with_fns(
-					sspath,
+					path,
 					|_| {}, /* skip_prepare */
 					|fs_tt| {
 						let ett = match fs_tt {
@@ -138,6 +144,7 @@ impl BehMacroInclude for IncludeTTAndFixUnkStartToken {
 	) -> TreeResult<Self::Result> {
 		arg0.get_str_with_fns(
 			|sspath| {
+				let sspath = Path::new(sspath);
 				load_file_and_automake_tree_with_fns(
 					sspath,
 					|p_string| {
@@ -238,10 +245,14 @@ impl BehMacroInclude for IncludeStr {
 	) -> TreeResult<Self::Result> {
 		arg0.get_str_with_fns(
 			|sspath| {
-				let data = match std::fs::read_to_string(sspath) {
+				let path = Path::new(sspath);
+				let data = match std::fs::read_to_string(path) {
 					Ok(a) => a,
 					Err(e) => {
-						return LoadFileAndAutoMakeTreeErr::read_to_string(e, sspath)
+						let path = path
+							.canonicalize()
+							.map_or_else(|_| Cow::Borrowed(path), Cow::Owned);
+						return LoadFileAndAutoMakeTreeErr::read_to_string(e, path)
 							.into_tt_err(literal_span)
 							.into();
 					}
@@ -280,10 +291,14 @@ impl BehMacroInclude for IncludeArr {
 		arg0.get_str_with_fns(
 			|sspath| {
 				let vec = {
-					let mut file = match File::open(sspath) {
+					let path = Path::new(sspath);
+					let mut file = match File::open(path) {
 						Ok(a) => a,
 						Err(e) => {
-							return LoadFileAndAutoMakeTreeErr::read_to_string(e, sspath)
+							let path = path
+								.canonicalize()
+								.map_or_else(|_| Cow::Borrowed(path), Cow::Owned);
+							return LoadFileAndAutoMakeTreeErr::read_to_string(e, path)
 								.into_tt_err(literal_span)
 								.into();
 						}
@@ -291,7 +306,10 @@ impl BehMacroInclude for IncludeArr {
 
 					let mut vec = Vec::new(); // capacity is not required.
 					if let Err(e) = file.read_to_end(&mut vec) {
-						return LoadFileAndAutoMakeTreeErr::read_to_string(e, sspath)
+						let path = path
+							.canonicalize()
+							.map_or_else(|_| Cow::Borrowed(path), Cow::Owned);
+						return LoadFileAndAutoMakeTreeErr::read_to_string(e, path)
 							.into_tt_err(literal_span)
 							.into();
 					};

--- a/src/macros/include.rs
+++ b/src/macros/include.rs
@@ -4,7 +4,7 @@ use crate::{
 		group::g_stringify,
 		loader::{LoadFileAndAutoMakeTreeErr, load_file_and_automake_tree_with_fns},
 		result::TreeResult,
-		sg_err, ttry,
+		throw_sg_err, ttry,
 	},
 };
 use alloc::string::String;
@@ -338,7 +338,7 @@ where
 
 		let stream0 = iter.next();
 		if let Some(unk) = iter.next() {
-			sg_err! {
+			throw_sg_err! {
 				return [unk.span()]: "Specify a valid path to the file written with `\"/Test.tt\"`, or `'T'`, or use a group of different trees `[/, \"Test\", '/']`."
 			}
 		}
@@ -373,7 +373,7 @@ where
 				literal.span(),
 			)
 		}
-		Some(g_stream) => sg_err! {
+		Some(g_stream) => throw_sg_err! {
 			return [g_stream.span()]: "The path was expected as a single string (example: \"../test.tt\") or a path formatted as separate TokenTrees (example: ['.' '.' test \".tt\"])."
 		},
 	}

--- a/src/trees/group.rs
+++ b/src/trees/group.rs
@@ -24,11 +24,11 @@ pub fn check_correct_endgroup<'i>(
 
 		let mut iter = endgroup.iter();
 		if let Some(a) = iter.next() {
-			if let Err(..) = write!(str, "`{}`", a) {
+			if let Err(..) = write!(str, "`{a}`") {
 				return str;
 			}
 			for a in iter {
-				if let Err(..) = write!(str, ", `{}`", a) {
+				if let Err(..) = write!(str, ", `{a}`") {
 					return str;
 				}
 			}
@@ -117,7 +117,7 @@ fn __g_stringify(tt: TokenTree2, w: &mut impl Write) -> TreeResult<()> {
 		}
 		TokenTree2::Ident(i) => {
 			if let Err(e) = w.write_str(&i.to_string()) {
-				let debug = format!("{:?}", e);
+				let debug = format!("{e:?}");
 				sg_err! {
 					return [i.span()]: "Ident, ", #debug
 				}
@@ -125,7 +125,7 @@ fn __g_stringify(tt: TokenTree2, w: &mut impl Write) -> TreeResult<()> {
 		}
 		TokenTree2::Punct(p) => {
 			if let Err(e) = w.write_char(p.as_char()) {
-				let debug = format!("{:?}", e);
+				let debug = format!("{e:?}");
 				sg_err! {
 					return [p.span()]: "Punct, ", #debug
 				}
@@ -137,7 +137,7 @@ fn __g_stringify(tt: TokenTree2, w: &mut impl Write) -> TreeResult<()> {
 				|sspath| match w.write_str(sspath) {
 					Ok(..) => TreeResult::Ok(()),
 					Err(e) => {
-						let debug = format!("{:?}", e);
+						let debug = format!("{e:?}");
 						sg_err! {
 							return [l.span()]: "Literal, ", #debug
 						}

--- a/src/trees/group.rs
+++ b/src/trees/group.rs
@@ -1,4 +1,4 @@
-use crate::{TreeResult, exprs::literal::ExprLit, trees::sg_err, trees::ttry};
+use crate::{exprs::literal::ExprLit, throw_sg_err, trees::ttry, TreeResult};
 use alloc::{
 	fmt::Write,
 	format,
@@ -57,7 +57,7 @@ pub fn check_correct_endgroup<'i>(
 						};
 						if !is_valid {
 							let e_group_str = make_endroup_str(endgroup);
-							sg_err! {
+							throw_sg_err! {
 								return [punct.span()]: "", #e_group_str, " was expected."
 							}
 						}
@@ -67,21 +67,21 @@ pub fn check_correct_endgroup<'i>(
 
 					_ => {
 						let e_group_str = make_endroup_str(endgroup);
-						sg_err! {
+						throw_sg_err! {
 							return [m_punct.span()]: "", #e_group_str, " was expected."
 						}
 					}
 				}
 			} else {
 				let e_group_str = make_endroup_str(endgroup);
-				sg_err! {
+				throw_sg_err! {
 					return [group.span()]: "", #e_group_str, " was expected."
 				}
 			}
 		}
 		Delimiter::Brace => return TreeResult::Ok(None), // `{ ... }`, ok
 		Delimiter::Bracket | Delimiter::None => {
-			sg_err! {
+			throw_sg_err! {
 				return [group.span()]: "Unsupported group type."
 			}
 		}
@@ -118,7 +118,7 @@ fn __g_stringify(tt: TokenTree2, w: &mut impl Write) -> TreeResult<()> {
 		TokenTree2::Ident(i) => {
 			if let Err(e) = w.write_str(&i.to_string()) {
 				let debug = format!("{e:?}");
-				sg_err! {
+				throw_sg_err! {
 					return [i.span()]: "Ident, ", #debug
 				}
 			}
@@ -126,7 +126,7 @@ fn __g_stringify(tt: TokenTree2, w: &mut impl Write) -> TreeResult<()> {
 		TokenTree2::Punct(p) => {
 			if let Err(e) = w.write_char(p.as_char()) {
 				let debug = format!("{e:?}");
-				sg_err! {
+				throw_sg_err! {
 					return [p.span()]: "Punct, ", #debug
 				}
 			}
@@ -138,7 +138,7 @@ fn __g_stringify(tt: TokenTree2, w: &mut impl Write) -> TreeResult<()> {
 					Ok(..) => TreeResult::Ok(()),
 					Err(e) => {
 						let debug = format!("{e:?}");
-						sg_err! {
+						throw_sg_err! {
 							return [l.span()]: "Literal, ", #debug
 						}
 					}
@@ -147,7 +147,7 @@ fn __g_stringify(tt: TokenTree2, w: &mut impl Write) -> TreeResult<()> {
 					let span = l.span();
 					let debug = e.into_tt_err(span);
 
-					sg_err! {
+					throw_sg_err! {
 						return [span]: "Literal, ", #debug
 					}
 				},

--- a/src/trees/loader.rs
+++ b/src/trees/loader.rs
@@ -1,6 +1,6 @@
 use alloc::{format, string::String};
 use proc_macro2::{Span, TokenStream as TokenStream2};
-use std::io::Error as IOError;
+use std::{borrow::Cow, io::Error as IOError, path::Path};
 use syn::Error as SynError;
 
 /// Variants of errors when loading a file and presenting it as a set of compiler trees.
@@ -8,7 +8,7 @@ use syn::Error as SynError;
 pub enum LoadFileAndAutoMakeTreeErr<'a> {
 	/// The error type for I/O operations of the
 	/// [Read], [Write], [Seek], and associated traits.
-	ReadToString { err: IOError, path: &'a str },
+	ReadToString { err: IOError, path: Cow<'a, Path> },
 
 	/// Error returned when a Syn parser cannot parse the input tokens.
 	ParseStr(SynError),
@@ -18,24 +18,24 @@ impl<'a> LoadFileAndAutoMakeTreeErr<'a> {
 	/// The error type for I/O operations of the
 	/// [Read], [Write], [Seek], and associated traits.
 	#[inline]
-	pub const fn read_to_string(err: IOError, path: &'a str) -> Self {
+	pub const fn read_to_string(err: IOError, path: Cow<'a, Path>) -> Self {
 		Self::ReadToString { err, path }
 	}
 
 	/// Convert an error to a syntax tree.
-	#[inline]
 	pub fn into_tt_err(self, span: Span) -> TokenStream2 {
 		match self {
 			Self::ReadToString { err, path } => {
+				let spath = format!("{path:?}"); // TODO REFACTORME
 				let se = format!("{err:?}");
 				sg_err! {
-					[span]: "Error loading file, err: ", #se, ", path: ", #path, "."
+					[span]: "Error loading file, err: '", #se, "', path: ", #spath, "."
 				}
 			}
 			Self::ParseStr(e) => {
 				let se = format!("{e:?}");
 				sg_err! {
-					[span]: "Failed to convert to tree `tt`: ", #se, "."
+					[span]: "Failed to convert to tree `tt`: '", #se, "'."
 				}
 			}
 		}
@@ -45,7 +45,7 @@ impl<'a> LoadFileAndAutoMakeTreeErr<'a> {
 #[allow(dead_code)]
 /// Load the file and present it as a compiler tree set.
 pub fn load_file_and_automake_tree(
-	path: &str,
+	path: &Path,
 
 	// Preprocessing a file loaded into a String before passing it directly to the parser.
 	//
@@ -57,7 +57,7 @@ pub fn load_file_and_automake_tree(
 
 /// Load the file and present it as a compiler tree set.
 pub fn load_file_and_automake_tree_with_fns<'a, R>(
-	path: &'a str,
+	path: &'a Path,
 
 	// Preprocessing a file loaded into a String before passing it directly to the parser.
 	//
@@ -69,7 +69,12 @@ pub fn load_file_and_automake_tree_with_fns<'a, R>(
 ) -> R {
 	let mut data = match std::fs::read_to_string(path) {
 		Ok(a) => a,
-		Err(e) => return err(LoadFileAndAutoMakeTreeErr::ReadToString { err: e, path: path }),
+		Err(e) => {
+			let path = path
+				.canonicalize()
+				.map_or_else(|_| Cow::Borrowed(path), Cow::Owned);
+			return err(LoadFileAndAutoMakeTreeErr::read_to_string(e, path));
+		}
 	};
 
 	if data.is_empty() {

--- a/src/trees/loader.rs
+++ b/src/trees/loader.rs
@@ -17,7 +17,7 @@ pub enum LoadFileAndAutoMakeTreeErr<'a> {
 impl<'a> LoadFileAndAutoMakeTreeErr<'a> {
 	/// The error type for I/O operations of the
 	/// [Read], [Write], [Seek], and associated traits.
-	#[inline(always)]
+	#[inline]
 	pub const fn read_to_string(err: IOError, path: &'a str) -> Self {
 		Self::ReadToString { err, path }
 	}

--- a/src/trees/loader.rs
+++ b/src/trees/loader.rs
@@ -28,13 +28,13 @@ impl<'a> LoadFileAndAutoMakeTreeErr<'a> {
 			Self::ReadToString { err, path } => {
 				let spath = format!("{path:?}"); // TODO REFACTORME
 				let se = format!("{err:?}");
-				sg_err! {
+				throw_sg_err! {
 					[span]: "Error loading file, err: '", #se, "', path: ", #spath, "."
 				}
 			}
 			Self::ParseStr(e) => {
 				let se = format!("{e:?}");
-				sg_err! {
+				throw_sg_err! {
 					[span]: "Failed to convert to tree `tt`: '", #se, "'."
 				}
 			}

--- a/src/trees/loader.rs
+++ b/src/trees/loader.rs
@@ -27,13 +27,13 @@ impl<'a> LoadFileAndAutoMakeTreeErr<'a> {
 	pub fn into_tt_err(self, span: Span) -> TokenStream2 {
 		match self {
 			Self::ReadToString { err, path } => {
-				let se = format!("{:?}", err);
+				let se = format!("{err:?}");
 				sg_err! {
 					[span]: "Error loading file, err: ", #se, ", path: ", #path, "."
 				}
 			}
 			Self::ParseStr(e) => {
-				let se = format!("{:?}", e);
+				let se = format!("{e:?}");
 				sg_err! {
 					[span]: "Failed to convert to tree `tt`: ", #se, "."
 				}

--- a/src/trees/result.rs
+++ b/src/trees/result.rs
@@ -11,7 +11,7 @@ pub enum TreeResult<Ok> {
 }
 
 impl<T> From<TokenStream2> for TreeResult<T> {
-	#[inline(always)]
+	#[inline]
 	fn from(e: TokenStream2) -> Self {
 		Self::Err(e)
 	}

--- a/src/trees/search.rs
+++ b/src/trees/search.rs
@@ -12,7 +12,7 @@ pub(crate) enum SearchGroup {
 }
 
 impl From<TokenStream2> for SearchGroup {
-	#[inline(always)]
+	#[inline]
 	fn from(e: TokenStream2) -> Self {
 		Self::Error(e)
 	}

--- a/src/trees/sq_err.rs
+++ b/src/trees/sq_err.rs
@@ -1,16 +1,16 @@
 /// A small macro that allows you to prepare
 /// an error tree and throw it to the user.
-macro_rules! sg_err {
+macro_rules! throw_sg_err {
 	// return macro `compile_error!`.
 	[ return $($tt:tt)* ] => {
-		return sg_err! {
+		return throw_sg_err! {
 			$($tt)*
 		}
 	};
 
 	// break macro `compile_error!` with a concatenator.
 	[ break $($tt:tt)* ] => {
-		break sg_err! {
+		break throw_sg_err! {
 			$($tt)*
 		}
 	};


### PR DESCRIPTION
1.0.6
===================
- refactor: replace `sq_err` with `throw_sq_err`
- feat: improve error output details
- fix: fix weird `space` indent for editorconfig
- build: update library versions
- refactor: switching from mandatory feature `inline(always)` to less mandatory `inline`
- refactor: fix warnings for new `clippy`
- build: update library version to `1.0.6`
